### PR TITLE
Refactor app into PWA mobile experience

### DIFF
--- a/assets/data/config.json
+++ b/assets/data/config.json
@@ -1,0 +1,41 @@
+{
+  "user": {
+    "name": "Алексей",
+    "pin": "1234",
+    "language": "ru"
+  },
+  "balance": {
+    "amount": 267345.0,
+    "currency": "₽"
+  },
+  "allowances": {
+    "data": {
+      "used": 21.3,
+      "total": 30
+    },
+    "calls": {
+      "used": 600,
+      "total": 600
+    }
+  },
+  "tariffs": [
+    {
+      "id": "internet",
+      "name": "Вместе Дешевле 1.1",
+      "description": "30 ГБ трафика, мессенджеры безлимит",
+      "addons": [
+        { "id": "5gb", "label": "Купить 5 ГБ", "amount": 299 },
+        { "id": "1gb", "label": "Купить 1 ГБ", "amount": 99 }
+      ]
+    },
+    {
+      "id": "calls",
+      "name": "Вместе Дешевле 1.1",
+      "description": "Безлимит внутри сети, 600 мин на другие",
+      "addons": [
+        { "id": "100min", "label": "Купить 100 минут", "amount": 259 },
+        { "id": "50min", "label": "Купить 50 минут", "amount": 149 }
+      ]
+    }
+  ]
+}

--- a/assets/fonts/Inter[wght].ttf
+++ b/assets/fonts/Inter[wght].ttf
@@ -1,0 +1,1 @@
+404: Not Found

--- a/assets/icons/icon-192.svg
+++ b/assets/icons/icon-192.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a84ff"/>
+      <stop offset="100%" stop-color="#a955f7"/>
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" rx="40" fill="url(#g)"/>
+  <path d="M60 64h72a16 16 0 0 1 0 32H84a12 12 0 0 0 0 24h56" fill="none" stroke="#fff" stroke-width="14" stroke-linecap="round"/>
+  <circle cx="96" cy="144" r="12" fill="#fff"/>
+</svg>

--- a/assets/icons/icon-512.svg
+++ b/assets/icons/icon-512.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="rg" cx="30%" cy="20%" r="80%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#0a84ff"/>
+    </radialGradient>
+    <linearGradient id="lg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a84ff"/>
+      <stop offset="100%" stop-color="#a955f7"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="110" fill="url(#lg)"/>
+  <circle cx="160" cy="160" r="110" fill="url(#rg)" opacity="0.35"/>
+  <path d="M140 180c0-44 36-80 80-80h140c44 0 80 36 80 80s-36 80-80 80h-98c-22 0-40 18-40 40s18 40 40 40h134" fill="none" stroke="#fff" stroke-width="36" stroke-linecap="round"/>
+  <circle cx="256" cy="388" r="32" fill="#fff"/>
+</svg>

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,835 @@
+/* --- Root Variables --- */
+:root {
+  color-scheme: light dark;
+  --font-family: "Inter", "Manrope", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --radius-lg: 28px;
+  --radius-md: 20px;
+  --radius-sm: 14px;
+  --blur-heavy: 32px;
+  --blur-medium: 18px;
+  --shadow-strong: 0 30px 60px rgba(10, 132, 255, 0.16);
+  --shadow-soft: 0 18px 42px rgba(0, 0, 0, 0.28);
+  --transition-fast: 160ms ease;
+  --transition-medium: 320ms cubic-bezier(0.22, 1, 0.36, 1);
+  --transition-slow: 420ms cubic-bezier(0.22, 1, 0.36, 1);
+  --app-max-width: min(480px, 100vw);
+  --primary: #a955f7;
+  --accent: #0a84ff;
+  --success: #27ae60;
+  --danger: #ff453a;
+  --text-strong: #ffffff;
+  --text-soft: rgba(255, 255, 255, 0.72);
+  --text-muted: rgba(255, 255, 255, 0.52);
+  --glass-border: rgba(255, 255, 255, 0.16);
+  --glass-bg: rgba(12, 12, 22, 0.72);
+  --surface: rgba(36, 36, 62, 0.65);
+  --surface-alt: rgba(20, 20, 34, 0.72);
+  --bg: #080812;
+  --bg-gradient: radial-gradient(circle at 20% -10%, rgba(169, 85, 247, 0.25), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(10, 132, 255, 0.25), transparent 50%),
+    linear-gradient(160deg, rgba(8, 8, 18, 1) 0%, rgba(10, 10, 22, 1) 100%);
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --text-strong: #101012;
+    --text-soft: rgba(16, 16, 32, 0.72);
+    --text-muted: rgba(16, 16, 32, 0.54);
+    --glass-border: rgba(255, 255, 255, 0.32);
+    --glass-bg: rgba(255, 255, 255, 0.62);
+    --surface: rgba(255, 255, 255, 0.82);
+    --surface-alt: rgba(255, 255, 255, 0.68);
+    --bg: #f6f7fb;
+    --bg-gradient: radial-gradient(circle at 20% -10%, rgba(169, 85, 247, 0.22), transparent 45%),
+      radial-gradient(circle at 80% 0%, rgba(10, 132, 255, 0.22), transparent 60%),
+      linear-gradient(160deg, #f6f7fb 0%, #eef0ff 100%);
+  }
+}
+
+/* --- Theme Overrides --- */
+.app-shell[data-theme="light"] {
+  --text-strong: #101012;
+  --text-soft: rgba(16, 16, 32, 0.72);
+  --text-muted: rgba(16, 16, 32, 0.54);
+  --glass-border: rgba(255, 255, 255, 0.32);
+  --glass-bg: rgba(255, 255, 255, 0.68);
+  --surface: rgba(255, 255, 255, 0.86);
+  --surface-alt: rgba(255, 255, 255, 0.7);
+  --bg: #f6f7fb;
+  --bg-gradient: radial-gradient(circle at 20% -10%, rgba(169, 85, 247, 0.18), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(10, 132, 255, 0.18), transparent 60%),
+    linear-gradient(160deg, #f6f7fb 0%, #eef0ff 100%);
+}
+
+.app-shell[data-theme="dark"] {
+  --text-strong: #ffffff;
+  --text-soft: rgba(255, 255, 255, 0.82);
+  --text-muted: rgba(255, 255, 255, 0.56);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-bg: rgba(8, 8, 18, 0.78);
+  --surface: rgba(28, 28, 48, 0.72);
+  --surface-alt: rgba(24, 24, 42, 0.86);
+  --bg: #080812;
+  --bg-gradient: radial-gradient(circle at 20% -10%, rgba(169, 85, 247, 0.35), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(10, 132, 255, 0.32), transparent 60%),
+    linear-gradient(160deg, rgba(8, 8, 18, 1) 0%, rgba(12, 12, 26, 1) 100%);
+}
+
+/* --- Base Styles --- */
+* {
+  box-sizing: border-box;
+}
+
+@font-face {
+  font-family: "Inter";
+  src: url("../assets/fonts/Inter[wght].ttf") format("truetype");
+  font-display: swap;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-family);
+  background: var(--bg-gradient);
+  color: var(--text-strong);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  -webkit-font-smoothing: antialiased;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(10, 132, 255, 0.2), transparent 55%),
+    linear-gradient(315deg, rgba(169, 85, 247, 0.15), transparent 55%);
+  pointer-events: none;
+  z-index: -2;
+}
+
+noscript {
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 8, 18, 0.9);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-size: 1.1rem;
+  z-index: 1000;
+}
+
+/* --- App Shell --- */
+.app-shell {
+  position: relative;
+  width: var(--app-max-width);
+  max-width: 100%;
+  height: 100vh;
+  max-height: 900px;
+  border-radius: clamp(0px, 6vw, 38px);
+  overflow: hidden;
+  background: transparent;
+  transition: background-color var(--transition-slow), color var(--transition-slow);
+  isolation: isolate;
+}
+
+.app-shell.theme-transition {
+  animation: themeFade 0.4s ease;
+}
+
+.glass-overlay {
+  position: absolute;
+  inset: 0;
+  background: var(--glass-bg);
+  backdrop-filter: blur(var(--blur-heavy)) saturate(140%);
+  border: 1px solid var(--glass-border);
+  z-index: -1;
+  transition: background var(--transition-slow), backdrop-filter var(--transition-slow);
+}
+
+.screen-root {
+  position: relative;
+  width: 100%;
+  height: calc(100% - 84px);
+  overflow: hidden;
+  display: grid;
+}
+
+.screen {
+  position: absolute;
+  inset: 0;
+  padding: clamp(20px, 4vw, 28px);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background: transparent;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(12px) scale(0.98);
+  transition: opacity var(--transition-medium), transform var(--transition-medium);
+}
+
+.screen.is-active {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.screen-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 12px;
+  position: relative;
+}
+
+.screen-header h1 {
+  font-size: clamp(1.4rem, 3vw, 1.8rem);
+  font-weight: 800;
+  margin: 0;
+}
+
+.back-button {
+  position: absolute;
+  left: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  border: none;
+  background: var(--surface);
+  color: var(--text-strong);
+  box-shadow: var(--shadow-soft);
+  cursor: pointer;
+  transition: transform var(--transition-fast), background var(--transition-fast);
+}
+
+.back-button:active {
+  transform: scale(0.94);
+}
+
+/* --- Splash Screen --- */
+.splash {
+  align-items: center;
+  justify-content: center;
+  gap: 32px;
+}
+
+.logo-stack {
+  display: grid;
+  place-items: center;
+  gap: 18px;
+}
+
+.logo-emblem {
+  width: 140px;
+  height: 140px;
+  border-radius: 38px;
+  background: linear-gradient(135deg, rgba(10, 132, 255, 0.42), rgba(169, 85, 247, 0.88));
+  backdrop-filter: blur(22px);
+  display: grid;
+  place-items: center;
+  font-size: 64px;
+  font-weight: 800;
+  color: #fff;
+  box-shadow: var(--shadow-strong);
+  transform: scale(0.6) rotate(-12deg);
+  opacity: 0;
+}
+
+.logo-title {
+  text-align: center;
+}
+
+.logo-title h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 4vw, 2.2rem);
+  font-weight: 800;
+}
+
+.logo-title p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.primary-action {
+  margin-top: 12px;
+  align-self: center;
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity var(--transition-medium), transform var(--transition-medium);
+}
+
+.primary-action.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* --- PIN Screen --- */
+.pin-screen {
+  gap: 32px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.pin-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+}
+
+.pin-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.pin-dots {
+  display: flex;
+  gap: 16px;
+}
+
+.pin-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: transparent;
+  border: 2px solid var(--surface-alt);
+  transition: background var(--transition-fast), border var(--transition-fast), transform var(--transition-fast);
+}
+
+.pin-dot.is-filled {
+  background: linear-gradient(145deg, var(--accent), var(--primary));
+  border-color: transparent;
+  transform: scale(1.1);
+}
+
+.pin-dot.is-error {
+  animation: shake 600ms ease;
+}
+
+.keypad {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+
+.keypad button {
+  aspect-ratio: 1;
+  border-radius: 28px;
+  border: none;
+  background: var(--surface);
+  color: var(--text-strong);
+  font-size: 1.6rem;
+  font-weight: 600;
+  box-shadow: var(--shadow-soft);
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+}
+
+.keypad button:active {
+  transform: scale(0.96);
+}
+
+/* --- Main Screen --- */
+.main-screen {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 18px;
+}
+
+.main-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 8px;
+}
+
+.profile-chip {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.profile-avatar {
+  width: 52px;
+  height: 52px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(10, 132, 255, 0.55), rgba(169, 85, 247, 0.55));
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: #fff;
+  box-shadow: var(--shadow-strong);
+}
+
+.profile-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.profile-meta h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.profile-meta span {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.balance-card {
+  background: linear-gradient(145deg, rgba(10, 132, 255, 0.9), rgba(169, 85, 247, 0.9));
+  border-radius: var(--radius-lg);
+  padding: 28px;
+  color: #fff;
+  box-shadow: var(--shadow-strong);
+  position: relative;
+  overflow: hidden;
+}
+
+.balance-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.35), transparent 55%);
+  opacity: 0.6;
+}
+
+.balance-card h3 {
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.balance-card .balance-amount {
+  margin: 18px 0 0;
+  font-size: clamp(2.2rem, 8vw, 3.1rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.balance-card .balance-subtext {
+  margin: 12px 0 0;
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.widget-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.widget-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px;
+  border-radius: var(--radius-md);
+  background: var(--surface-alt);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), var(--shadow-soft);
+  position: relative;
+  overflow: hidden;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.widget-card:hover {
+  transform: translateY(-2px);
+}
+
+.widget-info {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.widget-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: rgba(10, 132, 255, 0.18);
+  display: grid;
+  place-items: center;
+  color: var(--accent);
+  font-size: 1.6rem;
+}
+
+.widget-card[data-type="calls"] .widget-icon {
+  background: rgba(39, 174, 96, 0.2);
+  color: var(--success);
+}
+
+.widget-text h3 {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.widget-text span {
+  display: block;
+  margin-top: 6px;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.widget-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.progress-ring {
+  width: 70px;
+  height: 70px;
+  position: relative;
+}
+
+.progress-ring svg {
+  transform: rotate(-90deg);
+}
+
+.progress-ring circle {
+  fill: none;
+  stroke-width: 9;
+  stroke-linecap: round;
+}
+
+/* --- Floating Navigation --- */
+.floating-nav {
+  position: absolute;
+  bottom: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: calc(100% - 32px);
+  background: rgba(12, 12, 22, 0.8);
+  backdrop-filter: blur(var(--blur-medium));
+  border-radius: 26px;
+  padding: 10px;
+  display: flex;
+  justify-content: space-around;
+  gap: 6px;
+  box-shadow: var(--shadow-soft);
+}
+
+.nav-item {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 4px;
+  border-radius: 18px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  transition: color var(--transition-fast), transform var(--transition-fast), background var(--transition-fast);
+}
+
+.nav-item .icon {
+  font-size: 1.4rem;
+}
+
+.nav-item.is-active {
+  color: #fff;
+  background: linear-gradient(135deg, rgba(10, 132, 255, 0.55), rgba(169, 85, 247, 0.55));
+  box-shadow: 0 12px 30px rgba(10, 132, 255, 0.18);
+}
+
+/* --- Tariff Screens --- */
+.tariff-screen {
+  gap: 18px;
+}
+
+.section-card {
+  padding: 24px;
+  border-radius: var(--radius-lg);
+  background: var(--surface-alt);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 18px;
+  position: relative;
+  overflow: hidden;
+}
+
+.section-card p {
+  margin: 0;
+  color: var(--text-soft);
+}
+
+.progress-meter {
+  position: relative;
+  width: min(240px, 70vw);
+  margin: 0 auto;
+}
+
+.progress-meter canvas {
+  width: 100%;
+  height: auto;
+}
+
+.meter-label {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  gap: 6px;
+}
+
+.meter-label strong {
+  font-size: clamp(2rem, 8vw, 2.8rem);
+}
+
+.meter-label span {
+  color: var(--text-muted);
+}
+
+.action-group {
+  display: grid;
+  gap: 12px;
+}
+
+/* --- Settings --- */
+.settings-list {
+  display: grid;
+  gap: 12px;
+}
+
+.setting-item {
+  padding: 18px 20px;
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  color: var(--text-soft);
+  position: relative;
+  overflow: hidden;
+}
+
+.setting-item span {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.setting-item[data-action="logout"] {
+  color: var(--danger);
+}
+
+/* --- Buttons --- */
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 16px 22px;
+  border-radius: 20px;
+  border: none;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.button:active {
+  transform: scale(0.96);
+}
+
+.button-primary {
+  color: #fff;
+  background: linear-gradient(135deg, rgba(10, 132, 255, 0.9), rgba(169, 85, 247, 0.9));
+  box-shadow: var(--shadow-strong);
+}
+
+.button-secondary {
+  color: var(--text-strong);
+  background: var(--surface);
+  box-shadow: var(--shadow-soft);
+}
+
+.button-ghost {
+  background: transparent;
+  color: var(--accent);
+}
+
+.loading-dots {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.loading-dots span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  animation: pulse 900ms infinite ease-in-out;
+}
+
+.loading-dots span:nth-child(2) {
+  animation-delay: 120ms;
+}
+
+.loading-dots span:nth-child(3) {
+  animation-delay: 240ms;
+}
+
+/* --- Toasts --- */
+.toast-stack {
+  position: absolute;
+  inset-inline: 16px;
+  bottom: 120px;
+  display: grid;
+  gap: 12px;
+  pointer-events: none;
+}
+
+.toast {
+  padding: 16px 18px;
+  border-radius: 18px;
+  background: rgba(12, 12, 22, 0.82);
+  color: #fff;
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity var(--transition-medium), transform var(--transition-medium);
+}
+
+.toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toast[data-tone="success"] {
+  background: rgba(39, 174, 96, 0.88);
+}
+
+.toast[data-tone="error"] {
+  background: rgba(255, 69, 58, 0.88);
+}
+
+/* --- Ripple --- */
+.ripple {
+  position: absolute;
+  border-radius: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.6) 0%, transparent 70%);
+  animation: ripple 600ms ease-out;
+  pointer-events: none;
+}
+
+/* --- Gestures --- */
+.gesture-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+}
+
+/* --- Animations --- */
+@keyframes ripple {
+  to {
+    transform: translate(-50%, -50%) scale(2.6);
+    opacity: 0;
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(0.9);
+    opacity: 0.6;
+  }
+  50% {
+    transform: scale(1.2);
+    opacity: 1;
+  }
+}
+
+@keyframes shake {
+  10%,
+  90% {
+    transform: translateX(-3px);
+  }
+  20%,
+  80% {
+    transform: translateX(5px);
+  }
+  30%,
+  50%,
+  70% {
+    transform: translateX(-8px);
+  }
+  40%,
+  60% {
+    transform: translateX(8px);
+  }
+}
+
+@keyframes fadeBlur {
+  from {
+    opacity: 0;
+    filter: blur(18px);
+    transform: scale(0.94);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: scale(1);
+  }
+}
+
+@keyframes themeFade {
+  from {
+    filter: blur(12px);
+    opacity: 0.7;
+  }
+  to {
+    filter: blur(0);
+    opacity: 1;
+  }
+}
+
+.fade-blur-enter {
+  animation: fadeBlur var(--transition-slow) forwards;
+}
+
+/* --- Utilities --- */
+.text-muted {
+  color: var(--text-muted);
+}
+
+.hidden {
+  display: none !important;
+}
+
+@media (min-width: 900px) {
+  body {
+    padding: 40px 0;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,182 +1,25 @@
-<!DOCTYPE html>  
-<html lang="ru">  
-<head>  
-<meta charset="utf-8">  
-<title>Минималистичный редактор</title>  
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">  
-<style>  
-:root {  
-  --bg: #111;  
-  --fg: #eee;  
-  --accent: #0077ff;  
-  --border: #222;  
-  --radius: .4rem;  
-  --tab-h: 50px;  
-  --fab: 52px;  
-  --font: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;  
-}  
-* { box-sizing:border-box; }  
-*:focus { outline: none !important; box-shadow:none !important; }  
-  
-body, html {  
-  height: 100%; margin: 0;  
-  font-family: var(--font);  
-  background: var(--bg);  
-  color: var(--fg);  
-  display: flex; flex-direction: column;  
-  overscroll-behavior: none;  
-}  
-.window { flex: 1; display: flex; }  
-textarea {  
-  flex: 1; border: none; outline: none;  
-  padding: 1rem;  
-  font-family: monospace;  
-  font-size: .9rem;  
-  background: var(--bg);  
-  color: var(--fg);  
-  resize: none;  
-  -webkit-user-modify: read-write-plaintext-only;  
-}  
-  
-.fab {  
-  position: fixed; bottom: 16px;  
-  width: var(--fab); height: var(--fab);  
-  border-radius: 50%;   
-  display: flex; align-items: center; justify-content: center;  
-  background: var(--accent);  
-  cursor: pointer;  
-  transition: background .2s, transform .1s;  
-  user-select: none;  
-  -webkit-tap-highlight-color: transparent;  
-}  
-.fab:active { transform: scale(0.92); }  
-.fab svg { width: 26px; height: 26px; fill: #fff; }  
-.fab:hover { background: #005ed1; }  
-#copyBtn { right: calc(16px + var(--fab) + 12px); background:#444; }  
-#pasteBtn { right: calc(16px + (var(--fab) + 12px) * 2); background:#444; }  
-#selectAllBtn { right: calc(16px + (var(--fab) + 12px) * 3); background:#444; }  
-#runBtn { right: 16px; }  
-  
-.topbar {  
-  height: var(--tab-h);  
-  display: flex; align-items: center; justify-content: center;  
-  background: #181818;  
-  border-bottom: 1px solid var(--border);  
-  font-size: .8rem;  
-  position: relative;  
-}  
-.topbar .title { color: var(--accent); font-weight: 600; }  
-#menuBtn {  
-  position: absolute; left: 12px; top: 50%; transform: translateY(-50%);  
-  width: 36px; height: 36px; display:flex; align-items:center; justify-content:center;  
-  cursor: pointer;  
-  -webkit-tap-highlight-color: transparent;  
-}  
-#menuBtn svg { width: 26px; height: 26px; fill: var(--fg); }  
-  
-.notice {  
-  position: fixed; top: calc(var(--tab-h) + 10px); right: 20px;  
-  background: #222; color: #fff;  
-  padding: .5rem .8rem; border-radius: var(--radius);  
-  font-size: .8rem; opacity: 0; transition: opacity .3s, transform .3s;  
-  transform: translateY(-10px);  
-}  
-.notice.show { opacity: 1; transform: translateY(0); }  
-</style>  
-</head>  
-<body>  
-  
-<div class="topbar">  
-  <div id="menuBtn" title="Меню" role="button" tabindex="-1">  
-    <!-- иконка меню -->  
-    <svg viewBox="0 0 24 24"><path d="M3 6h18v2H3V6zm0 5h18v2H3v-2zm0 5h18v2H3v-2z"/></svg>  
-  </div>  
-  <div class="title">Редактор</div>  
-</div>  
-  
-<section id="codeWin" class="window">  
-  <textarea id="code" spellcheck="false"><!DOCTYPE html>  
-<html lang="ru">  
-<head>  
-  <meta charset="utf-8">  
-  <title>Demo</title>  
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">  
-  <style>  
-    body { margin: 2rem; font-family: system-ui; background:#111; color:#eee; }  
-    h1 { color:#0077ff; }  
-  </style>  
-</head>  
-<body>  
-  <h1>Привет, мир!</h1>  
-  <p>Это минималистичный предпросмотр.</p>  
-</body>  
-</html></textarea>  
-</section>  
-  
-<div class="fab" id="selectAllBtn" title="Выделить всё" role="button" tabindex="-1">  
-  <!-- иконка all -->  
-  <svg viewBox="0 0 24 24"><path d="M4 4h16v16H4V4zm2 2v12h12V6H6z"/></svg>  
-</div>  
-  
-<div class="fab" id="pasteBtn" title="Вставить" role="button" tabindex="-1">  
-  <!-- иконка paste -->  
-  <svg viewBox="0 0 24 24"><path d="M19 2h-4.18A3 3 0 0012 0a3 3 0 00-2.82 2H5a2 2 0 00-2 2v16a2   
-  2 0 002 2h14a2 2 0 002-2V4a2 2 0 00-2-2zM12 2a1 1 0 110 2 1 1 0 010-2zM5   
-  20V4h2v3h10V4h2v16H5z"/></svg>  
-</div>  
-  
-<div class="fab" id="copyBtn" title="Копировать" role="button" tabindex="-1">  
-  <!-- иконка copy -->  
-  <svg viewBox="0 0 24 24"><path d="M16 1H4a2 2 0 00-2 2v14h2V3h12V1zm3 4H8a2 2 0 00-2 2v14a2 2 0   
-  002 2h11a2 2 0 002-2V7a2 2 0 00-2-2zm0 16H8V7h11v14z"/></svg>  
-</div>  
-  
-<div class="fab" id="runBtn" title="Запустить" role="button" tabindex="-1">  
-  <!-- иконка play -->  
-  <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>  
-</div>  
-  
-<div class="notice" id="notice"></div>  
-  
-<script>  
-const codeEl = document.getElementById('code');  
-const runBtn = document.getElementById('runBtn');  
-const copyBtn = document.getElementById('copyBtn');  
-const pasteBtn = document.getElementById('pasteBtn');  
-const selectAllBtn = document.getElementById('selectAllBtn');  
-const notice = document.getElementById('notice');  
-const menuBtn = document.getElementById('menuBtn');  
-  
-function showNotice(msg) {  
-  notice.textContent = msg;  
-  notice.classList.add('show');  
-  setTimeout(() => notice.classList.remove('show'), 1500);  
-}  
-  
-function runCode() {  
-  const blob = new Blob([codeEl.value], {type:'text/html'});  
-  window.open(URL.createObjectURL(blob), '_blank');  
-}  
-async function copyCode() {  
-  try { await navigator.clipboard.writeText(codeEl.value); showNotice("Скопировано"); }  
-  catch { showNotice("Ошибка копирования"); }  
-}  
-async function pasteCode() {  
-  try { codeEl.setRangeText(await navigator.clipboard.readText()); showNotice("Вставлено"); }  
-  catch { showNotice("Ошибка вставки"); }  
-}  
-function selectAllCode() {  
-  codeEl.setSelectionRange(0, codeEl.value.length);  
-  showNotice("Выделено");  
-}  
-
-runBtn.addEventListener('click', runCode);  
-copyBtn.addEventListener('click', copyCode);  
-pasteBtn.addEventListener('click', pasteCode);  
-selectAllBtn.addEventListener('click', selectAllCode);  
-menuBtn.addEventListener('click', () => {  
-  showNotice("Открыть меню (потом добавим боковую панель)");  
-});  
-</script>  
-</body>  
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0"
+    />
+    <title>BBank Neo</title>
+    <meta name="theme-color" content="#0a84ff" />
+    <link rel="manifest" href="./manifest.json" />
+    <link rel="preload" as="font" href="./assets/fonts/Inter[wght].ttf" type="font/ttf" crossorigin />
+    <link rel="stylesheet" href="./css/style.css" />
+  </head>
+  <body>
+    <noscript>Для работы приложения необходим JavaScript.</noscript>
+    <div id="app" class="app-shell" data-theme="auto">
+      <div class="glass-overlay"></div>
+      <main id="screen-root" class="screen-root" aria-live="polite"></main>
+      <nav id="floating-nav" class="floating-nav" aria-label="Основная навигация"></nav>
+      <div id="toast-stack" class="toast-stack" role="status" aria-live="assertive"></div>
+    </div>
+    <script type="module" src="./js/app.js"></script>
+  </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,396 @@
+import { AppState } from "./state.js";
+import { UIManager } from "./ui.js";
+
+const screenRoot = document.getElementById("screen-root");
+const navRoot = document.getElementById("floating-nav");
+const toastRoot = document.getElementById("toast-stack");
+
+const ui = new UIManager({ root: screenRoot, navRoot, toastRoot });
+let pinBuffer = "";
+let previousBalance = 0;
+let isAuthenticating = false;
+
+const LANG = {
+  ru: {
+    wrongPin: "Неверный PIN. Попробуйте ещё раз",
+    paymentsSoon: "Раздел скоро будет доступен",
+    cardsSoon: "Виртуальные карты в разработке",
+    purchaseSuccess: (label) => `Успешно: ${label}`,
+    insufficient: "Недостаточно средств",
+    logout: "Вы вышли из аккаунта",
+    pinChanged: "PIN-код обновлён",
+    namePrompt: "Введите новое имя",
+    languageSwitched: "Язык переключён"
+  },
+  en: {
+    wrongPin: "Incorrect PIN. Try again",
+    paymentsSoon: "Payments section coming soon",
+    cardsSoon: "Cards are on the way",
+    purchaseSuccess: (label) => `Purchased: ${label}`,
+    insufficient: "Insufficient balance",
+    logout: "Signed out",
+    pinChanged: "PIN updated",
+    namePrompt: "Enter a new name",
+    languageSwitched: "Language updated"
+  }
+};
+
+async function boot() {
+  const config = await fetchConfig();
+  const state = AppState.initialise(config);
+  previousBalance = state.balance.amount;
+  ui.applyTheme(state.theme);
+  ui.refreshNavigationLanguage(state.user.language || "ru");
+  const initialScreen = state.onboardingComplete ? "home" : "splash";
+  const screen = ui.showScreen(initialScreen, state, { pushHistory: false });
+  AppState.state.history = [initialScreen];
+  AppState.persist();
+  ui.enhanceInteractions(screen);
+  bindScreenEvents(initialScreen, screen);
+  registerNavigation();
+  registerGlobalGestures();
+  registerServiceWorker();
+  animateSplash(screen);
+}
+
+async function fetchConfig() {
+  try {
+    const response = await fetch("./assets/data/config.json", { cache: "no-store" });
+    if (!response.ok) throw new Error("Config load failed");
+    return await response.json();
+  } catch (error) {
+    console.error(error);
+    return {};
+  }
+}
+
+function animateSplash(screen) {
+  const logo = screen?.querySelector("#app-logo");
+  if (!logo) return;
+  requestAnimationFrame(() => {
+    logo.style.transition = "transform 900ms cubic-bezier(0.22, 1, 0.36, 1), opacity 900ms";
+    logo.style.opacity = "1";
+    logo.style.transform = "scale(1) rotate(0deg)";
+  });
+  const button = screen.querySelector('[data-action="continue"]');
+  if (button) {
+    setTimeout(() => button.classList.add("is-visible"), 600);
+  }
+}
+
+function registerNavigation() {
+  navRoot.addEventListener("click", (event) => {
+    const button = event.target.closest(".nav-item");
+    if (!button) return;
+    const target = button.dataset.target;
+    switch (target) {
+      case "home":
+        navigate("home");
+        break;
+      case "settings":
+        navigate("settings");
+        break;
+      case "payments":
+        ui.showToast(LANG[AppState.state.user.language].paymentsSoon, "neutral");
+        break;
+      case "cards":
+        ui.showToast(LANG[AppState.state.user.language].cardsSoon, "neutral");
+        break;
+      default:
+        break;
+    }
+  });
+}
+
+function registerGlobalGestures() {
+  document.addEventListener("gesture:back", () => {
+    const previous = AppState.popHistory();
+    if (previous && previous !== ui.activeScreen) {
+      navigate(previous, { pushHistory: false });
+    } else if (ui.activeScreen !== "home") {
+      navigate("home", { pushHistory: false });
+    }
+  });
+  document.addEventListener("gesture:close", () => {
+    if (ui.activeScreen !== "home") {
+      navigate("home", { pushHistory: false });
+    }
+  });
+}
+
+function registerServiceWorker() {
+  if ("serviceWorker" in navigator) {
+    window.addEventListener("load", () => {
+      navigator.serviceWorker
+        .register("./sw.js")
+        .catch((error) => console.error("SW registration failed", error));
+    });
+  }
+}
+
+function navigate(screenId, options = {}) {
+  const screen = ui.showScreen(screenId, AppState.state, options);
+  if (!screen) return;
+  ui.enhanceInteractions(screen);
+  bindScreenEvents(screenId, screen);
+  if (screenId === "home" && options.pushHistory === false) {
+    AppState.state.history = ["home"];
+    AppState.persist();
+  }
+}
+
+function bindScreenEvents(screenId, screen) {
+  switch (screenId) {
+    case "splash": {
+      screen.querySelector('[data-action="continue"]').addEventListener("click", () => {
+        AppState.state.onboardingComplete = false;
+        navigate("pin");
+      });
+      break;
+    }
+    case "pin": {
+      buildKeypad(screen.querySelector('[data-role="keypad"]'));
+      break;
+    }
+    case "home": {
+      const balanceEl = screen.querySelector('[data-role="balance-amount"]');
+      ui.animateBalance(balanceEl, previousBalance, AppState.state.balance.amount);
+      previousBalance = AppState.state.balance.amount;
+      screen.querySelectorAll("[data-screen-target]").forEach((card) => {
+        card.addEventListener("click", () => {
+          const target = card.dataset.screenTarget;
+          navigate(target);
+        });
+      });
+      screen
+        .querySelector('[data-action="open-settings"]')
+        .addEventListener("click", () => navigate("settings"));
+      screen
+        .querySelector('[data-action="edit-name"]')
+        .addEventListener("click", handleChangeName);
+      screen.querySelectorAll(".progress-ring").forEach((ring) => {
+        const type = ring.closest(".widget-card").dataset.type;
+        if (type === "data") {
+          const fraction = AppState.state.allowances.data.total
+            ? AppState.state.allowances.data.used / AppState.state.allowances.data.total
+            : 0;
+          ui.drawProgressRing(ring, fraction, "accent");
+        } else {
+          const fraction = AppState.state.allowances.calls.total
+            ? 1 - AppState.state.allowances.calls.used / AppState.state.allowances.calls.total
+            : 0;
+          ui.drawProgressRing(ring, fraction, "success");
+        }
+      });
+      break;
+    }
+    case "internet":
+    case "calls": {
+      screen.querySelector("[data-action='back']").addEventListener("click", () => {
+        navigate("home", { pushHistory: false });
+      });
+      const canvas = screen.querySelector("canvas[data-role='canvas']");
+      if (canvas) {
+        drawAllowanceCanvas(canvas, screenId === "internet");
+      }
+      screen.querySelectorAll("[data-action='purchase']").forEach((button) => {
+        button.addEventListener("click", () => handlePurchase(button));
+      });
+      break;
+    }
+    case "settings": {
+      screen.querySelector('[data-action="change-theme"]').addEventListener("click", cycleTheme);
+      screen
+        .querySelector('[data-action="change-language"]')
+        .addEventListener("click", toggleLanguage);
+      screen.querySelector('[data-action="change-pin"]').addEventListener("click", handleChangePin);
+      screen.querySelector('[data-action="logout"]').addEventListener("click", handleLogout);
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+function buildKeypad(container) {
+  if (!container) return;
+  container.innerHTML = "";
+  const layout = [1, 2, 3, 4, 5, 6, 7, 8, 9, "", 0, "←"];
+  layout.forEach((symbol) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = symbol;
+    button.disabled = symbol === "";
+    container.appendChild(button);
+    if (symbol === "") return;
+    button.addEventListener("click", () => handlePinInput(symbol));
+  });
+}
+
+function handlePinInput(symbol) {
+  if (isAuthenticating) return;
+  if (symbol === "←") {
+    pinBuffer = pinBuffer.slice(0, -1);
+  } else if (pinBuffer.length < 4) {
+    pinBuffer += symbol.toString();
+  }
+  updatePinDots();
+  if (pinBuffer.length === 4) {
+    verifyPin();
+  }
+}
+
+function updatePinDots(isError = false) {
+  const dots = document.querySelectorAll(".pin-dot");
+  dots.forEach((dot, index) => {
+    dot.classList.toggle("is-filled", index < pinBuffer.length);
+    dot.classList.toggle("is-error", isError);
+  });
+  if (isError) {
+    setTimeout(() => {
+      dots.forEach((dot) => dot.classList.remove("is-error"));
+    }, 1200);
+  }
+}
+
+function verifyPin() {
+  const expected = AppState.state.user.pin;
+  isAuthenticating = true;
+  if (pinBuffer === expected) {
+    showFakeProgress().then(() => {
+      AppState.state.onboardingComplete = true;
+      AppState.state.lastLogin = Date.now();
+      AppState.persist();
+      pinBuffer = "";
+      navigate("home");
+      AppState.state.history = ["home"];
+      AppState.persist();
+      isAuthenticating = false;
+    });
+  } else {
+    const message = LANG[AppState.state.user.language].wrongPin;
+    ui.showToast(message, "error");
+    updatePinDots(true);
+    setTimeout(() => {
+      pinBuffer = "";
+      updatePinDots();
+      isAuthenticating = false;
+    }, 900);
+  }
+}
+
+function showFakeProgress() {
+  return new Promise((resolve) => {
+    const dots = document.createElement("div");
+    dots.className = "loading-dots";
+    dots.innerHTML = "<span></span><span></span><span></span>";
+    const keypad = document.querySelector("[data-role='keypad']");
+    keypad?.classList.add("hidden");
+    const header = document.querySelector(".pin-header");
+    header?.appendChild(dots);
+    setTimeout(() => {
+      dots.remove();
+      keypad?.classList.remove("hidden");
+      resolve();
+    }, 900);
+  });
+}
+
+function drawAllowanceCanvas(canvas, isData) {
+  const ctx = canvas.getContext("2d");
+  const { width, height } = canvas;
+  ctx.clearRect(0, 0, width, height);
+  const center = { x: width / 2, y: height / 2 };
+  const radius = Math.min(width, height) / 2 - 18;
+  const startAngle = -Math.PI / 2;
+  const baseColor = "rgba(255,255,255,0.1)";
+  ctx.lineWidth = 26;
+  ctx.lineCap = "round";
+  ctx.beginPath();
+  ctx.strokeStyle = baseColor;
+  ctx.arc(center.x, center.y, radius, 0, Math.PI * 2);
+  ctx.stroke();
+  const allowance = isData ? AppState.state.allowances.data : AppState.state.allowances.calls;
+  const total = allowance.total || 1;
+  const used = allowance.used || 0;
+  const fraction = isData ? used / total : 1 - used / total;
+  ctx.beginPath();
+  ctx.strokeStyle = isData ? "rgba(10,132,255,0.9)" : "rgba(39,174,96,0.9)";
+  ctx.arc(center.x, center.y, radius, startAngle, startAngle + fraction * Math.PI * 2);
+  ctx.stroke();
+}
+
+function handlePurchase(button) {
+  const amount = Number(button.dataset.amount || 0);
+  const addonId = button.dataset.addon;
+  if (amount > AppState.state.balance.amount) {
+    ui.showToast(LANG[AppState.state.user.language].insufficient, "error");
+    return;
+  }
+  AppState.adjustBalance(amount);
+  previousBalance = AppState.state.balance.amount;
+  if (addonId.includes("gb")) {
+    AppState.state.allowances.data.used = Math.max(
+      0,
+      AppState.state.allowances.data.used - (addonId === "5gb" ? 5 : 1)
+    );
+  } else {
+    AppState.state.allowances.calls.used = Math.max(
+      0,
+      AppState.state.allowances.calls.used - (addonId === "100min" ? 100 : 50)
+    );
+  }
+  AppState.persist();
+  ui.showToast(LANG[AppState.state.user.language].purchaseSuccess(button.textContent), "success");
+  navigate("home", { pushHistory: false });
+}
+
+function cycleTheme() {
+  const order = ["auto", "dark", "light"];
+  const currentIndex = order.indexOf(AppState.state.theme || "auto");
+  const next = order[(currentIndex + 1) % order.length];
+  AppState.state.theme = next;
+  AppState.persist();
+  ui.applyTheme(next);
+  navigate("settings", { pushHistory: false });
+}
+
+function toggleLanguage() {
+  const next = AppState.state.user.language === "ru" ? "en" : "ru";
+  AppState.update("user.language", next);
+  ui.showToast(LANG[next].languageSwitched, "success");
+  ui.refreshNavigationLanguage(next);
+  navigate("settings", { pushHistory: false });
+}
+
+function handleChangePin() {
+  const promptText = AppState.state.user.language === "en" ? "Enter new 4-digit PIN" : "Введите новый PIN из 4 цифр";
+  const nextPin = window.prompt(promptText, "");
+  if (nextPin && /^\d{4}$/.test(nextPin)) {
+    AppState.update("user.pin", nextPin);
+    ui.showToast(LANG[AppState.state.user.language].pinChanged, "success");
+  }
+}
+
+function handleChangeName() {
+  const lang = AppState.state.user.language;
+  const promptText = lang === "en" ? "Enter your name" : LANG[lang].namePrompt;
+  const nextName = window.prompt(promptText, AppState.state.user.name);
+  if (nextName && nextName.trim()) {
+    AppState.update("user.name", nextName.trim());
+    navigate("home", { pushHistory: false });
+  }
+}
+
+function handleLogout() {
+  AppState.state.onboardingComplete = false;
+  AppState.persist();
+  ui.showToast(LANG[AppState.state.user.language].logout, "neutral");
+  navigate("pin", { pushHistory: false });
+  AppState.state.history = ["pin"];
+  AppState.persist();
+  pinBuffer = "";
+  updatePinDots();
+}
+
+boot();

--- a/js/state.js
+++ b/js/state.js
@@ -1,0 +1,178 @@
+/**
+ * StateManager handles persistence, hydration and mutation of the application state.
+ * It exposes a reactive-style API to be consumed by UIManager and app logic.
+ */
+export class StateManager {
+  constructor(storageKey = "bbank-app-state") {
+    this.storageKey = storageKey;
+    this.state = {
+      user: {
+        name: "",
+        pin: "",
+        language: "ru"
+      },
+      theme: "auto",
+      balance: {
+        amount: 0,
+        currency: "₽"
+      },
+      allowances: {
+        data: { used: 0, total: 0 },
+        calls: { used: 0, total: 0 }
+      },
+      tariffs: [],
+      history: [],
+      onboardingComplete: false,
+      lastLogin: null
+    };
+    this.listeners = new Map();
+  }
+
+  /**
+   * Initialise the state from config and localStorage.
+   * @param {object} remoteConfig - JSON config fetched from assets/data/config.json.
+   */
+  initialise(remoteConfig) {
+    const persisted = this.#readFromStorage();
+    const merged = this.#deepMerge(this.state, remoteConfig || {});
+    this.state = this.#deepMerge(merged, persisted || {});
+    this.persist();
+    this.emit("init", this.state);
+    return this.state;
+  }
+
+  /**
+   * Subscribe to state changes.
+   * @param {string} key
+   * @param {(state: object) => void} callback
+   */
+  on(key, callback) {
+    if (!this.listeners.has(key)) {
+      this.listeners.set(key, new Set());
+    }
+    this.listeners.get(key).add(callback);
+  }
+
+  /**
+   * Remove listener subscription.
+   */
+  off(key, callback) {
+    if (!this.listeners.has(key)) return;
+    this.listeners.get(key).delete(callback);
+  }
+
+  /**
+   * Persist the state to localStorage.
+   */
+  persist() {
+    try {
+      const payload = JSON.stringify(this.state);
+      window.localStorage.setItem(this.storageKey, payload);
+    } catch (error) {
+      console.error("State persistence failed", error);
+    }
+  }
+
+  /**
+   * Update state by key path and emit change events.
+   * @param {string} path - dot.notation path
+   * @param {any} value
+   */
+  update(path, value) {
+    const segments = path.split(".");
+    let cursor = this.state;
+    for (let i = 0; i < segments.length - 1; i += 1) {
+      const key = segments[i];
+      cursor[key] = cursor[key] ?? {};
+      cursor = cursor[key];
+    }
+    cursor[segments.at(-1)] = value;
+    this.persist();
+    this.emit(path, this.state);
+    return this.state;
+  }
+
+  /**
+   * Append to history stack.
+   */
+  pushHistory(screenId) {
+    const history = [...this.state.history, screenId];
+    this.state.history = history.slice(-20);
+    this.persist();
+    this.emit("history", this.state);
+  }
+
+  /**
+   * Pop the latest screen from history.
+   */
+  popHistory() {
+    const history = [...this.state.history];
+    history.pop();
+    this.state.history = history;
+    this.persist();
+    this.emit("history", this.state);
+    return history.at(-1) ?? null;
+  }
+
+  /**
+   * Adjust balance amount and persist.
+   */
+  adjustBalance(delta) {
+    const next = Math.max(0, Number(this.state.balance.amount) - Number(delta));
+    this.state.balance.amount = Number(next.toFixed(2));
+    this.persist();
+    this.emit("balance", this.state);
+    return this.state.balance.amount;
+  }
+
+  /**
+   * Update allowance usage for a resource (data or calls).
+   */
+  updateAllowance(type, usedDelta) {
+    const allowance = this.state.allowances[type];
+    if (!allowance) return;
+    allowance.used = Math.max(0, allowance.used - usedDelta);
+    this.persist();
+    this.emit("allowances", this.state);
+  }
+
+  /**
+   * Utility to emit change events.
+   */
+  emit(key, payload) {
+    if (!this.listeners.has(key)) return;
+    this.listeners.get(key).forEach((cb) => cb(payload));
+  }
+
+  /**
+   * Try to read state snapshot from storage.
+   */
+  #readFromStorage() {
+    try {
+      const raw = window.localStorage.getItem(this.storageKey);
+      return raw ? JSON.parse(raw) : null;
+    } catch (error) {
+      console.warn("Unable to parse stored state", error);
+      return null;
+    }
+  }
+
+  /**
+   * Deep merge helper for plain objects.
+   */
+  #deepMerge(target, source) {
+    if (!source || typeof source !== "object") return target;
+    const output = Array.isArray(target) ? [...target] : { ...target };
+    Object.keys(source).forEach((key) => {
+      const srcValue = source[key];
+      if (srcValue && typeof srcValue === "object" && !Array.isArray(srcValue)) {
+        output[key] = this.#deepMerge(output[key] || {}, srcValue);
+      } else {
+        output[key] = srcValue;
+      }
+    });
+    return output;
+  }
+}
+
+export const AppState = new StateManager("bbank-app-state-v2");

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,472 @@
+import { AppState } from "./state.js";
+
+/**
+ * UIManager encapsulates DOM manipulation, screen transitions, animations and feedback.
+ */
+export class UIManager {
+  constructor({ root, navRoot, toastRoot }) {
+    this.root = root;
+    this.navRoot = navRoot;
+    this.toastRoot = toastRoot;
+    this.activeScreen = null;
+    this.themeState = "auto";
+    this.toastQueue = [];
+    this.screens = new Map();
+    this.navConfig = [
+      { id: "home", icon: "🏠", labels: { ru: "Главная", en: "Home" } },
+      { id: "payments", icon: "💸", labels: { ru: "Платежи", en: "Payments" } },
+      { id: "cards", icon: "💳", labels: { ru: "Карты", en: "Cards" } },
+      { id: "settings", icon: "⚙️", labels: { ru: "Настройки", en: "Settings" } }
+    ];
+    this.#registerDefaultScreens();
+    this.#setupNav(AppState.state.user?.language ?? "ru");
+  }
+
+  /**
+   * Render a particular screen using the state snapshot.
+   */
+  showScreen(id, state, { pushHistory = true } = {}) {
+    const render = this.screens.get(id);
+    if (!render) {
+      console.warn(`Screen ${id} is not registered.`);
+      return;
+    }
+
+    if (pushHistory) {
+      AppState.pushHistory(id);
+    }
+
+    const previous = this.root.querySelector(".screen.is-active");
+    const nextScreen = render(state);
+    nextScreen.dataset.screen = id;
+    nextScreen.classList.add("screen");
+
+    this.#attachGestureLayer(nextScreen);
+
+    this.root.appendChild(nextScreen);
+    requestAnimationFrame(() => {
+      nextScreen.classList.add("is-active", "fade-blur-enter");
+      if (previous) {
+        previous.classList.remove("is-active");
+        setTimeout(() => previous.remove(), 360);
+      }
+    });
+    this.activeScreen = id;
+    this.#updateNavigation(id);
+    return nextScreen;
+  }
+
+  /**
+   * Update the floating navigation buttons.
+   */
+  #setupNav(language = "ru") {
+    this.navRoot.innerHTML = this.navConfig
+      .map(
+        (item) => `
+        <button class="nav-item" data-target="${item.id}">
+          <span class="icon" aria-hidden="true">${item.icon}</span>
+          <span>${item.labels[language] ?? item.labels.ru}</span>
+        </button>
+      `
+      )
+      .join("");
+    this.navRoot.querySelectorAll(".nav-item").forEach((button) => this.bindRipple(button));
+  }
+
+  refreshNavigationLanguage(language) {
+    this.#setupNav(language);
+    this.#updateNavigation(this.activeScreen ?? "home");
+  }
+
+  #updateNavigation(targetId) {
+    const items = this.navRoot.querySelectorAll(".nav-item");
+    items.forEach((button) => {
+      button.classList.toggle("is-active", button.dataset.target === targetId);
+    });
+  }
+
+  /**
+   * Present toast notifications with queueing behaviour.
+   */
+  showToast(message, tone = "neutral") {
+    const toast = document.createElement("div");
+    toast.className = "toast";
+    toast.dataset.tone = tone;
+    toast.textContent = message;
+    this.toastRoot.appendChild(toast);
+    requestAnimationFrame(() => toast.classList.add("is-visible"));
+    this.toastQueue.push(toast);
+    setTimeout(() => this.#dismissToast(toast), 3200);
+  }
+
+  #dismissToast(toast) {
+    toast.classList.remove("is-visible");
+    setTimeout(() => {
+      toast.remove();
+      this.toastQueue = this.toastQueue.filter((item) => item !== toast);
+    }, 400);
+  }
+
+  /**
+   * Control global theme state with transition.
+   */
+  applyTheme(theme) {
+    const rootShell = document.getElementById("app");
+    if (!rootShell) return;
+    if (theme === "auto") {
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      rootShell.dataset.theme = prefersDark ? "dark" : "light";
+    } else {
+      rootShell.dataset.theme = theme;
+    }
+    rootShell.classList.add("theme-transition");
+    setTimeout(() => rootShell.classList.remove("theme-transition"), 400);
+    this.themeState = theme;
+  }
+
+  /**
+   * Create ripple and haptic feedback on interactive elements.
+   */
+  bindRipple(element) {
+    if (!element) return;
+    element.addEventListener("click", (event) => {
+      this.#vibrate(15);
+      const rect = element.getBoundingClientRect();
+      const ripple = document.createElement("span");
+      ripple.className = "ripple";
+      const size = Math.max(rect.width, rect.height);
+      ripple.style.width = ripple.style.height = `${size}px`;
+      ripple.style.left = `${event.clientX - rect.left}px`;
+      ripple.style.top = `${event.clientY - rect.top}px`;
+      element.appendChild(ripple);
+      setTimeout(() => ripple.remove(), 600);
+    });
+  }
+
+  /**
+   * Attach ripple behaviour to all interactive elements inside container.
+   */
+  enhanceInteractions(container) {
+    container
+      .querySelectorAll(
+        "button, .widget-card, .setting-item, .profile-avatar, .nav-item"
+      )
+      .forEach((el) => this.bindRipple(el));
+  }
+
+  /**
+   * Update progress ring arcs.
+   */
+  drawProgressRing(element, fraction, tone = "accent") {
+    const svg = element.querySelector("svg");
+    if (!svg) return;
+    const circle = svg.querySelector("circle[data-role='progress']");
+    const radius = circle.r.baseVal.value;
+    const circumference = radius * 2 * Math.PI;
+    circle.style.strokeDasharray = `${circumference} ${circumference}`;
+    circle.style.strokeDashoffset = `${circumference - fraction * circumference}`;
+    circle.style.stroke = tone === "success" ? "var(--success)" : "var(--accent)";
+  }
+
+  /**
+   * Apply animated counter to balance amount.
+   */
+  animateBalance(element, fromValue, toValue, duration = 700) {
+    const start = performance.now();
+    const format = (value) =>
+      new Intl.NumberFormat(AppState.state.user.language === "en" ? "en-US" : "ru-RU", {
+        style: "currency",
+        currency: AppState.state.balance.currency === "₽" ? "RUB" : "USD",
+        currencyDisplay: "symbol"
+      }).format(value);
+
+    const step = (timestamp) => {
+      const progress = Math.min(1, (timestamp - start) / duration);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      const current = fromValue + (toValue - fromValue) * eased;
+      element.textContent = format(current);
+      if (progress < 1) requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+  }
+
+  /**
+   * Register screens and their templates.
+   */
+  #registerDefaultScreens() {
+    this.screens.set("splash", (state) => this.#renderSplash(state));
+    this.screens.set("pin", (state) => this.#renderPin(state));
+    this.screens.set("home", (state) => this.#renderHome(state));
+    this.screens.set("internet", (state) => this.#renderInternet(state));
+    this.screens.set("calls", (state) => this.#renderCalls(state));
+    this.screens.set("settings", (state) => this.#renderSettings(state));
+  }
+
+  #renderSplash() {
+    const screen = document.createElement("section");
+    screen.className = "screen splash";
+    screen.innerHTML = `
+      <div class="logo-stack">
+        <div class="logo-emblem" id="app-logo">B</div>
+        <div class="logo-title">
+          <h2>BBank Neo</h2>
+          <p>Ваша связь и финансы в одном касании</p>
+        </div>
+      </div>
+      <button class="button button-primary primary-action" data-action="continue">
+        Начать
+      </button>
+    `;
+    return screen;
+  }
+
+  #renderPin(state) {
+    const screen = document.createElement("section");
+    screen.className = "screen pin-screen";
+    screen.innerHTML = `
+      <div class="pin-header">
+        <h2 class="pin-title">${state.user.name || "Добро пожаловать"}</h2>
+        <p class="text-muted">Введите PIN для доступа</p>
+        <div class="pin-dots" role="group" aria-label="PIN индикатор">
+          ${Array.from({ length: 4 })
+            .map(() => '<span class="pin-dot" data-role="dot"></span>')
+            .join("")}
+        </div>
+      </div>
+      <div class="keypad" data-role="keypad"></div>
+    `;
+    return screen;
+  }
+
+  #renderHome(state) {
+    const screen = document.createElement("section");
+    screen.className = "screen main-screen";
+    const dataUsage = state.allowances.data;
+    const callsUsage = state.allowances.calls;
+    const dataFraction = dataUsage.total
+      ? Math.min(1, dataUsage.used / dataUsage.total)
+      : 0;
+    const callsFraction = callsUsage.total
+      ? Math.min(1, 1 - callsUsage.used / callsUsage.total)
+      : 0;
+    screen.innerHTML = `
+      <header class="main-header">
+        <div class="profile-chip">
+          <div class="profile-avatar" data-action="edit-name">${state.user.name
+            .charAt(0)
+            .toUpperCase()}</div>
+          <div class="profile-meta">
+            <span>${state.user.language === "en" ? "Welcome back" : "С возвращением"}</span>
+            <h2>${state.user.name}</h2>
+          </div>
+        </div>
+        <button class="button button-ghost" data-action="open-settings">⚙️</button>
+      </header>
+      <section class="balance-card" aria-live="polite">
+        <h3>${state.user.language === "en" ? "Current balance" : "Ваш баланс"}</h3>
+        <p class="balance-amount" data-role="balance-amount"></p>
+        <p class="balance-subtext">${state.user.language === "en"
+          ? "Актуально на сегодня"
+          : "Актуально на сегодня"}</p>
+      </section>
+      <section class="widget-grid">
+        <article class="widget-card" data-screen-target="internet" data-type="data">
+          <div class="widget-info">
+            <div class="widget-icon">🌐</div>
+            <div class="widget-text">
+              <h3>${state.user.language === "en" ? "Data" : "Интернет"}</h3>
+              <span>${dataUsage.used.toFixed(1)} из ${dataUsage.total.toFixed(1)} ГБ</span>
+            </div>
+          </div>
+          <div class="widget-meta">
+            <div class="progress-ring" aria-hidden="true">
+              <svg width="70" height="70">
+                <circle cx="35" cy="35" r="30" stroke="rgba(255,255,255,0.12)"></circle>
+                <circle data-role="progress" cx="35" cy="35" r="30" stroke="var(--accent)" stroke-dasharray="0" stroke-dashoffset="0"></circle>
+              </svg>
+            </div>
+            <span>${Math.round(dataFraction * 100)}%</span>
+          </div>
+        </article>
+        <article class="widget-card" data-screen-target="calls" data-type="calls">
+          <div class="widget-info">
+            <div class="widget-icon">📞</div>
+            <div class="widget-text">
+              <h3>${state.user.language === "en" ? "Calls" : "Звонки"}</h3>
+              <span>${callsUsage.used === callsUsage.total
+                ? state.user.language === "en"
+                  ? "Исчерпаны"
+                  : "Закончились"
+                : `${callsUsage.total - callsUsage.used} мин`}</span>
+            </div>
+          </div>
+          <div class="widget-meta">
+            <div class="progress-ring" aria-hidden="true">
+              <svg width="70" height="70">
+                <circle cx="35" cy="35" r="30" stroke="rgba(255,255,255,0.12)"></circle>
+                <circle data-role="progress" cx="35" cy="35" r="30" stroke="var(--success)" stroke-dasharray="0" stroke-dashoffset="0"></circle>
+              </svg>
+            </div>
+            <span>${Math.round(callsFraction * 100)}%</span>
+          </div>
+        </article>
+      </section>
+    `;
+    return screen;
+  }
+
+  #renderInternet(state) {
+    const tariff = state.tariffs?.find((item) => item.id === "internet");
+    const screen = document.createElement("section");
+    screen.className = "screen tariff-screen";
+    screen.innerHTML = `
+      <header class="screen-header">
+        <button class="back-button" data-action="back" aria-label="Назад">⟵</button>
+        <h1>${tariff?.name ?? "Интернет"}</h1>
+      </header>
+      <section class="section-card">
+        <p>${tariff?.description ?? "Управляйте пакетами трафика"}</p>
+        <div class="progress-meter">
+          <canvas width="300" height="300" data-role="canvas"></canvas>
+          <div class="meter-label">
+            <strong>${state.allowances.data.used.toFixed(1)}</strong>
+            <span>${state.user.language === "en" ? "of" : "из"} ${state.allowances.data.total.toFixed(1)} ГБ</span>
+          </div>
+        </div>
+        <div class="action-group" data-role="addon-group">
+          ${(tariff?.addons || [])
+            .map(
+              (addon) => `
+                <button class="button button-secondary" data-action="purchase" data-addon="${addon.id}" data-amount="${addon.amount}">
+                  ${addon.label} · ${addon.amount} ₽
+                </button>
+              `
+            )
+            .join("")}
+        </div>
+      </section>
+    `;
+    return screen;
+  }
+
+  #renderCalls(state) {
+    const tariff = state.tariffs?.find((item) => item.id === "calls");
+    const screen = document.createElement("section");
+    screen.className = "screen tariff-screen";
+    const minutesLeft = Math.max(0, tariff ? tariff.addons?.[0]?.amount ?? 0 : 0);
+    screen.innerHTML = `
+      <header class="screen-header">
+        <button class="back-button" data-action="back" aria-label="Назад">⟵</button>
+        <h1>${tariff?.name ?? "Звонки"}</h1>
+      </header>
+      <section class="section-card">
+        <p>${tariff?.description ?? "Контроль минут"}</p>
+        <div class="progress-meter">
+          <canvas width="300" height="300" data-role="canvas"></canvas>
+          <div class="meter-label">
+            <strong>${Math.max(0, tariff ? tariff.addons?.length ?? 0 : 0)}</strong>
+            <span>${state.user.language === "en" ? "available packs" : "пакетов доступно"}</span>
+          </div>
+        </div>
+        <div class="action-group" data-role="addon-group">
+          ${(tariff?.addons || [])
+            .map(
+              (addon) => `
+                <button class="button button-secondary" data-action="purchase" data-addon="${addon.id}" data-amount="${addon.amount}">
+                  ${addon.label} · ${addon.amount} ₽
+                </button>
+              `
+            )
+            .join("")}
+        </div>
+      </section>
+    `;
+    return screen;
+  }
+
+  #renderSettings(state) {
+    const screen = document.createElement("section");
+    screen.className = "screen tariff-screen";
+    screen.innerHTML = `
+      <header class="screen-header">
+        <h1>${state.user.language === "en" ? "Settings" : "Настройки"}</h1>
+      </header>
+      <section class="section-card settings-list">
+        <div class="setting-item" data-action="change-theme">
+          <div>
+            ${state.user.language === "en" ? "Theme" : "Тема"}
+            <span>${this.#themeLabel(state.theme)}</span>
+          </div>
+          <div>🌓</div>
+        </div>
+        <div class="setting-item" data-action="change-language">
+          <div>
+            ${state.user.language === "en" ? "Language" : "Язык"}
+            <span>${state.user.language.toUpperCase()}</span>
+          </div>
+          <div>🌐</div>
+        </div>
+        <div class="setting-item" data-action="change-pin">
+          <div>
+            ${state.user.language === "en" ? "Change PIN" : "Сменить PIN"}
+          </div>
+          <div>🔐</div>
+        </div>
+        <div class="setting-item" data-action="logout" data-role="logout">
+          <div>${state.user.language === "en" ? "Log out" : "Выход"}</div>
+          <div>🚪</div>
+        </div>
+      </section>
+    `;
+    return screen;
+  }
+
+  #themeLabel(theme) {
+    switch (theme) {
+      case "light":
+        return "Светлая";
+      case "dark":
+        return "Тёмная";
+      default:
+        return "Системная";
+    }
+  }
+
+  #attachGestureLayer(screen) {
+    const layer = document.createElement("div");
+    layer.className = "gesture-layer";
+    let startX = 0;
+    let startY = 0;
+    layer.addEventListener(
+      "touchstart",
+      (event) => {
+        const touch = event.changedTouches[0];
+        startX = touch.clientX;
+        startY = touch.clientY;
+      },
+      { passive: true }
+    );
+    layer.addEventListener(
+      "touchend",
+      (event) => {
+        const touch = event.changedTouches[0];
+        const deltaX = touch.clientX - startX;
+        const deltaY = touch.clientY - startY;
+        if (Math.abs(deltaX) > 60 && Math.abs(deltaY) < 50 && deltaX > 0) {
+          document.dispatchEvent(new CustomEvent("gesture:back"));
+        }
+        if (deltaY < -80 && Math.abs(deltaX) < 40) {
+          document.dispatchEvent(new CustomEvent("gesture:close"));
+        }
+      },
+      { passive: true }
+    );
+    screen.appendChild(layer);
+  }
+
+  #vibrate(ms) {
+    if (window.navigator?.vibrate) {
+      window.navigator.vibrate(ms);
+    }
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "BBank Neo",
+  "short_name": "BBank",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "orientation": "portrait",
+  "theme_color": "#0a84ff",
+  "background_color": "#080812",
+  "icons": [
+    {
+      "src": "./assets/icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "./assets/icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,50 @@
+const CACHE_NAME = "bbank-neo-cache-v1";
+const APP_SHELL = [
+  "./",
+  "./index.html",
+  "./css/style.css",
+  "./js/app.js",
+  "./js/ui.js",
+  "./js/state.js",
+  "./assets/data/config.json",
+  "./assets/icons/icon-192.svg",
+  "./assets/icons/icon-512.svg",
+  "./assets/fonts/Inter[wght].ttf",
+  "./manifest.json"
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(APP_SHELL))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") return;
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) return cached;
+      return fetch(event.request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+          return response;
+        })
+        .catch(() => caches.match("./index.html"));
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- rebuild the landing page into a modular mobile-first application shell with splash, PIN, home, service, and settings screens
- implement ES module architecture with state manager, UI manager, toasts, gestures, and offline-ready service worker
- redesign UI with Material/Glassmorphism styling, theme transitions, localized navigation, and animated balance/progress visuals

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e7ef869a408320a97c55e686a8f7c4